### PR TITLE
T7156: suppress sprintf format warnings at the source level

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = --pedantic -Wall -Werror -Wno-error=format-overflow= -std=c99 -O2
+AM_CFLAGS = --pedantic -Wall -Werror -std=c99 -O2
 AM_LDFLAGS = 
 
 ipaddrcheck_SOURCES = ipaddrcheck.c ipaddrcheck_functions.c

--- a/src/ipaddrcheck_functions.c
+++ b/src/ipaddrcheck_functions.c
@@ -578,10 +578,13 @@ int is_ipv4_range(char* range_str, int prefix_length, int verbose)
                 {
                     char left_pref_str[19];
 
-                    /* XXX: Prefix length size is checked elsewhere, so it can't be more than 2 characters (32)
+                    /* XXX: Prefix length size is checked elsewhere with a regex, so it can't be more than 2 characters (32)
                        and overflow cannot occur.
                      */
+                    #pragma GCC diagnostic push
+                    #pragma GCC diagnostic ignored "-Wformat-overflow="
                     sprintf(left_pref_str, "%s/%u", left, prefix_length);
+                    #pragma GCC diagnostic pop
                     CIDR* left_addr_with_pref = cidr_from_str(left_pref_str);
                     CIDR* left_net = cidr_addr_network(left_addr_with_pref);
                     if( cidr_contains(left_net, right_addr) == 0 )
@@ -679,10 +682,13 @@ int is_ipv6_range(char* range_str, int prefix_length, int verbose)
                 {
                     char left_pref_str[44];
 
-                    /* XXX: Prefix length size is checked elsewhere, so it can't be more than 3 characters (128)
+                    /* XXX: Prefix length size is checked elsewhere with a regex, so it can't be more than 3 characters (128)
                        and overflow cannot occur.
                      */
+                    #pragma GCC diagnostic push
+                    #pragma GCC diagnostic ignored "-Wformat-overflow="
                     sprintf(left_pref_str, "%s/%u", left, prefix_length);
+                    #pragma GCC diagnostic pop
                     CIDR* left_addr_with_pref = cidr_from_str(left_pref_str);
                     CIDR* left_net = cidr_addr_network(left_addr_with_pref);
                     if( cidr_contains(left_net, right_addr) == 0 )


### PR DESCRIPTION
...rather than with CFLAGS, so that it applies only to locations where it was proven safe and is protected against CFLAGS overrides.

This fixes the Debian package build.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

Use GCC diagnostic pragmas to supress a warning for selected lines.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
