### PR TITLE
T7199: changelog and package version update

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+ipaddrcheck (1.3) unstable; urgency=medium
+
+  * New option --range-prefix-length to require ranges to be within a subnet (Daniil Baturin).
+  * Options for checking IP ranges: --is-ipv4-range and --is-ipv6-range (Daniil Baturin).
+  * Fixed linker flags to build correctly on Debian Bullseye (John Eastabrook).
+  * Removed stale dependency on libcidr0-dev (Christian Breunig).
+
+ -- Daniil Baturin <daniil@vyos.io>  Tue, 25 Feb 2025 18:21:43 +0000
+
 ipaddrcheck (1.2) unstable; urgency=medium
 
   * Correct recognition of IPv4 /31 and IPv6 /127 as valid host addresses.


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Other (please describe): metadata update.

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
