### PR TITLE
T7557: Use PCRE2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,6 @@ AC_COPYRIGHT([Copyright (c) 2024 VyOS maintainers and contributors.])
 #AC_PROG_CC
 AM_PROG_CC_C_O
 
-AC_CHECK_HEADER([pcre.h], [], [AC_MSG_FAILURE([pcre.h is not found.])])
 AC_CHECK_HEADER([libcidr.h], [], [AC_MSG_FAILURE([libcidr.h is not found.])])
 
 AM_INIT_AUTOMAKE([gnu no-dist-gzip dist-bzip2 subdir-objects])
@@ -14,5 +13,6 @@ AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile man/Makefile])
 AC_CONFIG_HEADERS([src/config.h])
 
 PKG_CHECK_MODULES([CHECK], [check >= 0.9.4])
+PKG_CHECK_MODULES([PCRE2], [libpcre2-8])
 
 AC_OUTPUT

--- a/debian/control
+++ b/debian/control
@@ -2,11 +2,11 @@ Source: ipaddrcheck
 Section: contrib/net
 Priority: extra
 Maintainer: VyOS Package Maintainers <maintainers@vyos.net>
-Build-Depends: autoconf, debhelper (>= 9), libpcre3-dev, libcidr-dev, check
+Build-Depends: autoconf, debhelper (>= 9), libpcre2-dev, libcidr-dev, check
 Standards-Version: 3.9.6
 
 Package: ipaddrcheck
 Architecture: any
-Depends: libpcre3, libcidr0, ${shlibs:Depends}, ${misc:Depends}
+Depends: libpcre2-8-0, libcidr0, ${shlibs:Depends}, ${misc:Depends}
 Description: IPv4 and IPv6 address validation utility
  A validation utility for IPv4 and IPv6 addresses.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 AM_CFLAGS = --pedantic -Wall -Werror -std=c99 -O2
-AM_LDFLAGS = 
+AM_CPPFLAGS = $(PCRE2_CFLAGS)
 
 ipaddrcheck_SOURCES = ipaddrcheck.c ipaddrcheck_functions.c
-ipaddrcheck_LDADD = -lcidr -lpcre
+ipaddrcheck_LDADD = -lcidr $(PCRE2_LIBS)
 
 bin_PROGRAMS = ipaddrcheck

--- a/src/ipaddrcheck_functions.c
+++ b/src/ipaddrcheck_functions.c
@@ -41,25 +41,31 @@
 
 int regex_matches(const char* regex, const char* str)
 {
-    int offsets[1];
-    pcre *re;
+    pcre2_code *re;
     int rc;
-    const char *error;
-    int erroffset;
+    int out;
+    int error;
+    PCRE2_SIZE erroffset;
 
-    re = pcre_compile(regex, 0, &error, &erroffset, NULL);
+    re = pcre2_compile((PCRE2_SPTR)regex, PCRE2_ZERO_TERMINATED, 0, &error, &erroffset, NULL);
     assert(re != NULL);
 
-    rc = pcre_exec(re, NULL, str, strlen(str), 0, 0, offsets, 1);
+    pcre2_match_data *match = pcre2_match_data_create_from_pattern(re, NULL);
+
+    rc = pcre2_match(re, (PCRE2_SPTR)str, strlen(str), 0, 0, match, NULL);
 
     if( rc >= 0)
     {
-        return RESULT_SUCCESS;
+        out = RESULT_SUCCESS;
     }
     else
     {
-        return RESULT_FAILURE;
+        out = RESULT_FAILURE;
     }
+
+    pcre2_match_data_free(match);
+    pcre2_code_free(re);
+    return out;
 }
 
 

--- a/src/ipaddrcheck_functions.h
+++ b/src/ipaddrcheck_functions.h
@@ -23,11 +23,13 @@
 #ifndef IPADDRCHECK_FUNCTIONS_H
 #define IPADDRCHECK_FUNCTIONS_H
 
+#define PCRE2_CODE_UNIT_WIDTH 8
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <getopt.h>
-#include <pcre.h>
+#include <pcre2.h>
 #include <libcidr.h>
 
 #define INVALID_PROTO -1

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,3 +1,5 @@
+AM_CPPFLAGS = $(PCRE2_CFLAGS)
+
 TESTS = check_ipaddrcheck integration_tests.sh
 
 TESTS_ENVIRONMENT = top_srcdir=$(top_srcdir) PATH=.:$(top_srcdir)/src:$$PATH
@@ -5,4 +7,4 @@ TESTS_ENVIRONMENT = top_srcdir=$(top_srcdir) PATH=.:$(top_srcdir)/src:$$PATH
 check_PROGRAMS = check_ipaddrcheck
 check_ipaddrcheck_SOURCES = check_ipaddrcheck.c ../src/ipaddrcheck_functions.c
 check_ipaddrcheck_CFLAGS = @CHECK_CFLAGS@
-check_ipaddrcheck_LDADD = -lcidr -lpcre @CHECK_LIBS@
+check_ipaddrcheck_LDADD = -lcidr $(PCRE2_LIBS) @CHECK_LIBS@


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
PCRE3 is deprecated, use PCRE2.

Required for trixie image build.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-build/pull/978

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
