### PR TITLE
T8374: convert addresses to the host byte order before comparison in IPv4 range checks

### DIFF
--- a/src/ipaddrcheck_functions.c
+++ b/src/ipaddrcheck_functions.c
@@ -562,7 +562,7 @@ int is_ipv4_range(char* range_str, int prefix_length, int verbose)
             struct in_addr* left_in_addr = cidr_to_inaddr(left_addr, NULL);
             struct in_addr* right_in_addr = cidr_to_inaddr(right_addr, NULL);
 
-            if( left_in_addr->s_addr <= right_in_addr->s_addr )
+            if( ntohl(left_in_addr->s_addr) <= ntohl(right_in_addr->s_addr) )
             {
                 /* If non-zero prefix_length is given,
                    check if the right address is within the network of the first one. */

--- a/tests/check_ipaddrcheck.c
+++ b/tests/check_ipaddrcheck.c
@@ -408,6 +408,7 @@ START_TEST (test_is_ipv4_range)
     ck_assert_int_eq(is_ipv4_range("192.0.2.0-192.0.2.10", 0, 1), RESULT_SUCCESS);
     ck_assert_int_eq(is_ipv4_range("192.0.2.-", 0, 1), RESULT_FAILURE);
     ck_assert_int_eq(is_ipv4_range("192.0.2.99-192.0.2.11", 0, 1), RESULT_FAILURE);
+    ck_assert_int_eq(is_ipv4_range("192.0.2.0-1.8.2.1", 0, 1), RESULT_FAILURE);
 }
 END_TEST
 


### PR DESCRIPTION
The original logic didn't account for the fact that `in_addr->s_addr` is stored in the network by order (big endian) and shouldn't be compared directly without byte order conversion on little-endian architectures.

That made certain checks like `ipaddrcheck --verbose --is-ipv4-range 192.0.2.0-1.8.2.1` succeed, but the issue remained hidden because the comparison logic issue didn't affect more common bad ranges like `192.0.2.200-192.0.2.100`.

In my defense, the [POSIX docs for `netinet/in.h`](https://pubs.opengroup.org/onlinepubs/009695399/basedefs/netinet/in.h.html) doesn't say anything about the order and at the time I didn't realize the conversion happens much earlier than I thought.

Note that the IPv6 comparison logic is byte-by-byte from the start of the array, so it wasn't susceptible to that issue:

```
vyos_bld@75dc4f49e7e6:/vyos$ git diff
diff --git a/src/ipaddrcheck_functions.c b/src/ipaddrcheck_functions.c
index 09830a1..fa8351c 100644
--- a/src/ipaddrcheck_functions.c
+++ b/src/ipaddrcheck_functions.c
@@ -502,6 +502,7 @@ int compare_ipv6(struct in6_addr *left, struct in6_addr *right)
     int i = 0;
     for( i = 0; i < 16; i++ )
     {
+        printf("Comparing bytes %x and %x\n", left->s6_addr[i], right->s6_addr[i]);
         if (left->s6_addr[i] < right->s6_addr[i])
             return -1;
         else if (left->s6_addr[i] > right->s6_addr[i])

vyos_bld@75dc4f49e7e6:/vyos$ ./src/ipaddrcheck --is-ipv6-range aaaa:bbbb::1-aaaa:bbbb::10
Comparing bytes aa and aa
Comparing bytes aa and aa
Comparing bytes bb and bb
Comparing bytes bb and bb
Comparing bytes 0 and 0
Comparing bytes 0 and 0
Comparing bytes 0 and 0
Comparing bytes 0 and 0
Comparing bytes 0 and 0
Comparing bytes 0 and 0
Comparing bytes 0 and 0
Comparing bytes 0 and 0
Comparing bytes 0 and 0
Comparing bytes 0 and 0
Comparing bytes 0 and 0
Comparing bytes 1 and 10
```

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
