### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,3 @@ Mirror twin: `VyOS-Networks/ipaddrcheck`. Canonical side is **here** (`vyos/ipad
 - Used as a CLI-level validator — exit status 0/1 is the contract. Don't break stdout/stderr conventions or add chatty output.
 - `libcidr` is by Matthew Fuller (http://www.over-yonder.net/~fullermd/projects/libcidr) — Debian-packaged.
 - Adding a new flag: extend `src/ipaddrcheck.c`'s argument table and add a libcheck test under `tests/`.
-
----
-
-This file is mirrored on Confluence: [`vyos/ipaddrcheck`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818479310). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ C utility for IPv4/IPv6 address and prefix validation in shell scripts. Used by 
 
 - C, autotools (`configure.ac`, `Makefile.am`, autoconf 2.x).
 - Dependencies: `libcidr` (parsing), `libpcre2-8` (regex), `check >= 0.9.4` (test framework).
-- Debian packaging under `debian/`. Current source version `1.1`.
+- Debian packaging under `debian/`. Upstream autotools version `1.1` (`configure.ac`); current Debian package version `1.4` (`debian/changelog`).
 
 ## Build / test / run
 
@@ -25,7 +25,7 @@ dpkg-buildpackage -uc -us -tc -b
 ## Repository layout
 
 - `src/` — C sources (`ipaddrcheck.c`, headers, autotools `Makefile.am`).
-- `tests/` — libcheck unit tests.
+- `tests/` — libcheck C unit tests (`check_ipaddrcheck.c`) and shell integration tests (`assert.sh`, `integration_tests.sh`).
 - `man/` — manpages.
 - `debian/` — Debian packaging.
 - `configure.ac`, `Makefile.am`, `INSTALL`, `NEWS`, `ChangeLog`, `AUTHORS`, `COPYING` (GPL-2), `COPYING-LGPL` (LGPL-2.1).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+## Project purpose
+
+C utility for IPv4/IPv6 address and prefix validation in shell scripts. Used by VyOS as the canonical "is this string a valid IP / network / host / CIDR?" checker invoked from XML validators and conf-mode scripts. Fast and exit-status-driven (intended for `if ipaddrcheck --is-ipv4 ...; then ...`).
+
+## Tech stack
+
+- C, autotools (`configure.ac`, `Makefile.am`, autoconf 2.x).
+- Dependencies: `libcidr` (parsing), `libpcre2-8` (regex), `check >= 0.9.4` (test framework).
+- Debian packaging under `debian/`. Current source version `1.1`.
+
+## Build / test / run
+
+```
+autoreconf -fi          # generate configure
+./configure
+make
+make check              # uses libcheck unit tests under tests/
+make install            # installs into AC_PREFIX_DEFAULT (/usr)
+# Debian package
+dpkg-buildpackage -uc -us -tc -b
+```
+
+## Repository layout
+
+- `src/` — C sources (`ipaddrcheck.c`, headers, autotools `Makefile.am`).
+- `tests/` — libcheck unit tests.
+- `man/` — manpages.
+- `debian/` — Debian packaging.
+- `configure.ac`, `Makefile.am`, `INSTALL`, `NEWS`, `ChangeLog`, `AUTHORS`, `COPYING` (GPL-2), `COPYING-LGPL` (LGPL-2.1).
+
+## Cross-repo context
+
+One of the canonical 14 VyOS-image build packages, listed in `VyOS-Networks/vyos-build-packages/repos.toml`. Built into VyOS images by `vyos-build` and invoked at runtime by `vyos-1x` validators and conf-mode scripts. Sits in the §3.5 native-libraries category alongside `hvinfo`, `udp-broadcast-relay`, etc.
+
+## Conventions
+
+- Commit / PR title format: `component: T12345: description` (Phorge task ID at https://vyos.dev mandatory). Enforced by `vyos/.github` reusable workflows where consumed.
+- Branch model: `current` (rolling), `circinus` (1.5 LTS), `sagitta` (1.4 LTS), `equuleus` (1.3 LTS).
+- Maintained by the VyOS team (`maintainers@vyos.net`); license is GPL-2 + LGPL-2.1 dual.
+
+## Mirror relationship
+
+Mirror twin: `VyOS-Networks/ipaddrcheck`. Canonical side is **here** (`vyos/ipaddrcheck`).
+
+## Notes for future contributors
+
+- Used as a CLI-level validator — exit status 0/1 is the contract. Don't break stdout/stderr conventions or add chatty output.
+- `libcidr` is by Matthew Fuller (http://www.over-yonder.net/~fullermd/projects/libcidr) — Debian-packaged.
+- Adding a new flag: extend `src/ipaddrcheck.c`'s argument table and add a libcheck test under `tests/`.
+
+---
+
+This file is mirrored on Confluence: [`vyos/ipaddrcheck`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818479310). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
