### PR TITLE
T8943: migrate mirror wrapper to App-ready uniform stub (rollout 1b Task 5 canary)

### DIFF
--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -1,3 +1,6 @@
+# .github/workflows/pr-mirror-repo-sync.yml
+# DO NOT EDIT — managed by mirror-pipeline rollout.
+# To opt out: set vars.MIRROR_ENABLED=false in this repo's Actions variables.
 name: PR Mirror and Repo Sync
 
 on:
@@ -7,29 +10,21 @@ on:
   workflow_dispatch:
     inputs:
       sync_branch:
-        description: 'Branch to mirror'
         required: true
-        default: 'current'
-        type: choice
-        options:
-          - current
+        type: string
 
 permissions:
-  pull-requests: write
   contents: write
+  pull-requests: write
   issues: write
 
 jobs:
-  call-pr-mirror-repo-sync:
+  call:
     if: |
-      github.repository_owner == 'vyos' &&
-      (
-        github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
-      )
+      github.repository_owner == 'vyos'
+      && (github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch')
+      && vars.MIRROR_ENABLED != 'false'
     uses: vyos/.github/.github/workflows/pr-mirror-repo-sync.yml@current
     with:
-      sync_branch: ${{ github.event.inputs.sync_branch || 'current' }}
-    secrets:
-      PAT: ${{ secrets.PAT }}
-      REMOTE_OWNER: ${{ secrets.REMOTE_OWNER }}
+      sync_branch: ${{ inputs.sync_branch || github.event.pull_request.base.ref }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Rollout 1b (mirror pipeline PAT→App migration), **Task 5 canary consumer**. Switches this repo's mirror wrapper from explicit `secrets: PAT/REMOTE_OWNER` pass-through to `secrets: inherit`, and adopts the uniform stub shape. Behavior-neutral against the current PAT-using central workflow (`inherit` populates `PAT`/`REMOTE_OWNER` by name from org-level secrets); prepares for the App-token central-workflow update (Task 7).

**Template note:** the job `if:` now honors `vars.MIRROR_ENABLED` (per-repo kill-switch; default-on when the variable is unset). This is a canonical-template amendment driven by a Phase 0 CodeRabbit finding — it is propagated to the remaining 24 wrappers + the plan.

## Spec / Plan
- Plan: `~/.claude/plans/2026-05-26-mirror-rollout-1b-revised.md` Task 5
- Tracking: T8943
- Confluence: Mirror Pipeline Redesign — Spec v1 (871825417)

## Test plan
- [ ] After merge: a `workflow_dispatch` (or next merged PR on `current`) triggers the mirror via the new wrapper; a mirror PR still appears on `VyOS-Networks/ipaddrcheck`. Central workflow is still PAT-based at this stage — this verifies `secrets: inherit` correctly delivers `PAT`/`REMOTE_OWNER`.

🤖 Generated by [robots](https://vyos.io)