### PR TITLE
T8943: feat(mirror-rollout-2): adopt uniform wrapper stub

### DIFF
--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -6,7 +6,7 @@ name: PR Mirror and Repo Sync
 on:
   pull_request_target:
     types: [closed]
-    branches: [rolling]
+    branches: [rolling, production]
   workflow_dispatch:
     inputs:
       sync_branch:
@@ -14,16 +14,13 @@ on:
         type: string
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   call:
     if: |
       github.repository_owner == 'vyos'
       && (github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch')
-      && vars.MIRROR_ENABLED != 'false'
     uses: vyos/.github/.github/workflows/pr-mirror-repo-sync.yml@production
     with:
       sync_branch: ${{ inputs.sync_branch || github.event.pull_request.base.ref }}


### PR DESCRIPTION
Rollout 2 standardization (Plan Task 6 pilot). Mirror behavior on this consumer stays byte-identical post-merge — inclusion + kill-switch logic moves to the central workflow + consumers.yaml. This wrapper becomes a thin pass-through.

## Changes from post-1b wrapper

- `branches: [rolling]` → `[rolling, production]` (heterogeneous fleet)
- `permissions:` reduced to `contents: read` (central workflow holds writes via App tokens)
- Removed `vars.MIRROR_ENABLED != 'false'` gate from wrapper `if:` clause (kill-switch enforced in central workflow)

## Validation

`vyos/ipaddrcheck` is in [VyOS-Networks/.github mirror/consumers.yaml](https://github.com/VyOS-Networks/.github/blob/production/mirror/consumers.yaml) (sync_branches=[rolling]) — verified via post-Task-5 production smoke run [vyos/mirror-canary 26693380532](https://github.com/vyos/mirror-canary/actions/runs/26693380532). The central workflow already reads consumers.yaml on every mirror trigger and gates side effects on consumer_found==true.

Advances: T8943

🤖 Generated by [robots](https://vyos.io)