### PR TITLE
T8943: revert(mirror-rollout-2): restore post-1b wrapper on ipaddrcheck

### DIFF
--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -6,7 +6,7 @@ name: PR Mirror and Repo Sync
 on:
   pull_request_target:
     types: [closed]
-    branches: [rolling, production]
+    branches: [rolling]
   workflow_dispatch:
     inputs:
       sync_branch:
@@ -14,13 +14,16 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
+  issues: write
 
 jobs:
   call:
     if: |
       github.repository_owner == 'vyos'
       && (github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch')
+      && vars.MIRROR_ENABLED != 'false'
     uses: vyos/.github/.github/workflows/pr-mirror-repo-sync.yml@production
     with:
       sync_branch: ${{ inputs.sync_branch || github.event.pull_request.base.ref }}


### PR DESCRIPTION
PR #33 broke this consumer's mirror with startup_failure. Restoring the post-1b wrapper.

## Root cause

GitHub's reusable-workflow permissions model. The canonical stub set `permissions: contents: read`, but the central reusable workflow on vyos/.github@production declares `contents: write, pull-requests: write, issues: write` at top level.

Per [GitHub docs](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#access-and-permissions): 'If the calling workflow grants any of these permissions but the called workflow needs a higher level of access to a scope, the called workflow uses the permissions as specified by the called workflow.' But empirically the run failed with startup_failure — the validation is stricter than docs suggest.

## Follow-up

Canonical stub design is being revisited. Either (a) drop the central workflow's top-level `permissions:` block (App tokens handle all side effects; GITHUB_TOKEN unused), or (b) keep write permissions in the canonical stub. (a) is cleaner per spec §4.2.3 intent.

Mirror behavior on ipaddrcheck returns to byte-identical post-1b state.

Advances: T8943

🤖 Generated by [robots](https://vyos.io)