### PR TITLE
ci(mirror-rollout-4): add force_workspace backport companion wrapper

### DIFF
--- a/.github/workflows/force-workspace-backport.yml
+++ b/.github/workflows/force-workspace-backport.yml
@@ -1,0 +1,25 @@
+# .github/workflows/force-workspace-backport.yml
+# DO NOT EDIT — managed by mirror-pipeline Rollout 4.
+name: force_workspace backport companion
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  call:
+    # No-op on the public source (owner != VyOS-Networks); active on the mirrored target copy.
+    if: |
+      github.repository_owner == 'VyOS-Networks'
+      && github.event.issue.pull_request != null
+      && github.event.comment.user.login == 'mergify[bot]'
+      && contains(github.event.comment.body, 'No backport have been created')
+    uses: vyos/.github/.github/workflows/force-workspace-backport.yml@production
+    with:
+      mergify_comment_id: ${{ github.event.comment.id }}
+      mergify_comment_body: ${{ github.event.comment.body }}
+      target_pr_number: ${{ github.event.issue.number }}
+    secrets: inherit


### PR DESCRIPTION
Rollout 4 (IS-510, Phorge T8943). Adds the source-side force_workspace wrapper (mirrored to the VyOS-Networks twin; owner-guarded so it's inert here and active on the target). Calls the public reusable vyos/.github/.github/workflows/force-workspace-backport.yml@production. Inert until force_workspace_enabled is set per-consumer in consumers.yaml (currently false everywhere). Representative for the 13-repo byte-identical fan-out.

🤖 Generated by [robots](https://vyos.io)