### PR TITLE
test: mirror backport drift verification (1/2)

### DIFF
--- a/mirror-drift-canary.txt
+++ b/mirror-drift-canary.txt
@@ -1,0 +1,1 @@
+mirror backport drift canary — initial content


### PR DESCRIPTION
First half of a mirror backport drift canary. Adds a new file on the default branch; a follow-up PR modifies it to exercise the backport conflict path. Throwaway — reverted after verification. No release-train references.