### PR TITLE
test: mirror backport drift verification (2/2)

### DIFF
--- a/mirror-drift-canary.txt
+++ b/mirror-drift-canary.txt
@@ -1,1 +1,1 @@
-mirror backport drift canary — initial content
+mirror backport drift canary - modified content (triggers cherry-pick conflict)


### PR DESCRIPTION
Second half of the mirror backport drift canary. Modifies a file present on the default branch but absent on the LTS target — a backport will conflict, exercising the force-staging path. Throwaway; reverted after verification. No release-train references.