### PR TITLE
test: remove mirror backport drift canary file (cleanup)

### DIFF
--- a/mirror-drift-canary.txt
+++ b/mirror-drift-canary.txt
@@ -1,1 +1,0 @@
-mirror backport drift canary - modified content (triggers cherry-pick conflict)


### PR DESCRIPTION
Removes the throwaway canary file added by #38/#39. Cleanup of a completed verification. No release-train references.