### PR TITLE
ci: T9082: onboard CodeQL scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,4 +21,3 @@ jobs:
     with:
       languages: "['c-cpp']"
       build-mode: "none"
-      build-command: "make"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,3 +20,5 @@ jobs:
     uses: vyos/.github/.github/workflows/codeql-analysis.yml@b0082401423f12eb68200266227edc8bb54c9937
     with:
       languages: "['c-cpp']"
+      build-mode: "none"
+      build-command: "make"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,9 +4,17 @@ on:
   push:
     branches:
       - rolling
+    paths:
+      - '**'
+      - '!.github/**'
+      - '!**/*.md'
   pull_request:
     branches:
       - rolling
+    paths:
+      - '**'
+      - '!.github/**'
+      - '!**/*.md'
   schedule:
     - cron: '28 13 * * 0'
 
@@ -17,7 +25,7 @@ permissions:
 
 jobs:
   codeql-analysis-call:
-    uses: vyos/.github/.github/workflows/codeql-analysis.yml@b0082401423f12eb68200266227edc8bb54c9937
+    uses: vyos/.github/.github/workflows/codeql-analysis.yml@production
     with:
       languages: "['c-cpp']"
       build-mode: "none"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,22 @@
+name: "Perform CodeQL Analysis"
+
+on:
+  push:
+    branches:
+      - rolling
+  pull_request:
+    branches:
+      - rolling
+  schedule:
+    - cron: '28 13 * * 0'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  codeql-analysis-call:
+    uses: vyos/.github/.github/workflows/codeql-analysis.yml@b0082401423f12eb68200266227edc8bb54c9937
+    with:
+      languages: "['c-cpp']"


### PR DESCRIPTION
Adds a thin caller of the central CodeQL reusable workflow ([vyos/.github](https://github.com/vyos/.github) `codeql-analysis.yml`) — push/PR on `rolling` + weekly cron, `c-cpp`. Advisory only; not a required check.

**Canary PR** for the vyos-org CodeQL rollout ([T9082](https://vyos.dev/T9082), [IS-610](https://vyos.atlassian.net/browse/IS-610)) — validates [vyos/.github#155](https://github.com/vyos/.github/pull/155) pre-merge via a 3-commit sequence pinned to the Track-A feature SHA:
1. legacy autobuild path on codeql-action v4 (this commit);
2. deliberate invalid input combo — validation step must fail fast;
3. final shape (`build-mode: none`), coverage compared against run 1.

Pin flips to `@production` before merge, after [vyos/.github#155](https://github.com/vyos/.github/pull/155) lands.

Advances: IS-610

🤖 Generated by [robots](https://vyos.io)

[IS-610]: https://vyos.atlassian.net/browse/IS-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ